### PR TITLE
Prevent accessing 'openings' when current_entry is null

### DIFF
--- a/node_eval/node_eval.js
+++ b/node_eval/node_eval.js
@@ -181,7 +181,7 @@ function load_book_moves() {
             }
         }
 
-        openingname_text.innerHTML = current_entry.opening;
+        openingname_text.innerHTML = current_entry?.opening;
     }
 
     let entry = hub.looker.lookup(config.looker_api, hub.tree.node.parent.board);
@@ -242,7 +242,6 @@ function update_score() {
     
     if(pawn_count_w === 1) {
         spans_w += `<span class="captured-pieces-w-pawn captured-pieces-cpiece"></span>`;
-        console.log("hi");
     } else if (pawn_count_w > 1) {
         spans_w += `<span class="captured-pieces-w-${pawn_count_w}-pawns captured-pieces-cpiece"></span>`;
     }


### PR DESCRIPTION
I've ran the same game that crashed, now it does not.
And after analysing more games, it also did not crash.

Fixes #4 